### PR TITLE
ndkmediacodec always target API 21

### DIFF
--- a/external/android/libsfdec/codec_audio_mediacodec.cpp
+++ b/external/android/libsfdec/codec_audio_mediacodec.cpp
@@ -17,6 +17,11 @@
 #include <string.h>
 #include <inttypes.h>
 
+#ifdef __ANDROID_API__
+#undef __ANDROID_API__
+#define __ANDROID_API__ 21
+#endif
+
 #include <media/NdkMediaCodec.h>
 
 #include "sfdec_common.h"

--- a/external/android/libsfdec/sfdec_ndkmediacodec.cpp
+++ b/external/android/libsfdec/sfdec_ndkmediacodec.cpp
@@ -17,6 +17,11 @@
 #include <string.h>
 #include <inttypes.h>
 
+#ifdef __ANDROID_API__
+#undef __ANDROID_API__
+#define __ANDROID_API__ 21
+#endif
+
 #include <media/NdkMediaCodec.h>
 
 #include "sfdec_common.h"


### PR DESCRIPTION
- loaded as a plugin only for 21+
 - fix build with NDK unified headers